### PR TITLE
Allow the users to provide a genome file.

### DIFF
--- a/Get_DoGs_rpkm
+++ b/Get_DoGs_rpkm
@@ -19,6 +19,7 @@ parser.add_argument('-bam', action='store', dest='readspath', help='Sorted downs
 parser.add_argument('-s', action='store_true', default=False, dest='strand', help='strand specific, default is False')
 parser.add_argument('-dog', action='store', dest='annotation', help='DoGs annotation file',type=str)
 parser.add_argument('-suff', action='store', dest='base_name',default='', help='Suffix to add to output file',type=str)
+parser.add_argument('-genome', dest = 'genome', default = '', help = "Chromosomesize file", type = str)
 
 usr_input = parser.parse_args() 
 
@@ -41,6 +42,7 @@ if output_path[-1]=='/'  and len(output_path)>0:
 	output_path=output_path[:-1]
 
 S=usr_input.strand
+G=usr_input.genome
 
 if out_name is not '':
 	out_name='_'+out_name
@@ -103,9 +105,9 @@ os.remove(genome_path)
 
 #print "Coverage to Count DoGs reads..."
 if version > 2240:
-	annota_cov=annot_sort.coverage(reads,sorted=True,s=S,split=True)
+	annota_cov=annot_sort.coverage(reads,sorted=True,s=S,split=True, g=G)
 else :
-	annota_cov=reads.coverage(annot_sort,sorted=True,s=S,split=True)
+	annota_cov=reads.coverage(annot_sort,sorted=True,s=S,split=True, g=G)
 	
 df_cov=pybedtools.BedTool.to_dataframe(annota_cov)
 df_cov.columns=range(0,df_cov.shape[1])


### PR DESCRIPTION
Currently if you run this pipeline as is on say hg38 version of the genome this step of generating RPKM fails, usually with the error that it cannot find some chromosomes.  This fixes the error.